### PR TITLE
Give the fitweird div an ID

### DIFF
--- a/fitWeird.js
+++ b/fitWeird.js
@@ -33,10 +33,11 @@ var fillVars = function(){
 
 var setupFitWeird = function(){
 
-  if ( !document.getElementById('fitweird-width-px') ) {
+  if ( !document.getElementById('fitweird') ) {
     var newDiv = document.createElement('div');
     var newContent = '<span id=fitweird-width-px></span>px &times; <span id=fitweird-height-px></span>px ';
     newContent += ':: <span id=fitweird-width-em></span>em &times; <span id=fitweird-height-em></span>em';
+    newDiv.setAttribute('id', 'fitweird');
     newDiv.style.position = 'fixed';
     newDiv.style.bottom = '0';
     newDiv.style.right = '0';


### PR DESCRIPTION
It's be nice to have an ID on the whole fitweird div so we can manipulate it / check for it / etc. without having to go deeper and check for a span with an ID.

This adds an id of 'fitweird' to the instance created by init();
It also changes the conditional to query for this ID rather than #fitweird-width-px. Seems cleaner.
